### PR TITLE
Add GitHub Actions tests for this lab

### DIFF
--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
-      run: gcc -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std++0x
+      run: gcc -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test
       run: ./disemvowel_test

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -1,0 +1,34 @@
+name: gtest disemvowel
+
+on:
+  [push, pull_request]:
+    paths:
+    - disemvowel/**
+    paths-ignore:
+    - 'resources/**'
+    - '*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache gtest library
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-gtest-lib
+      with:
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
+        path: /usr/local/lib/libgtest.a
+        restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+    - name: Install gtest manually
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp *.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+    - name: Check ou the code
+      uses: actions/checkout@v2
+    - name: Compile test code
+      run: gcc -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std++0x
+    - name: Run test
+      run: ./disemvowel_test
+

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -21,10 +21,12 @@ jobs:
             ${{ runner.os }}-
     - name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
-    - name: Check ou the code
+    - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
       run: gcc -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std++0x
+      working-directory: disemvowel
     - name: Run test
       run: ./disemvowel_test
+      working-directory: disemvowel
 

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -1,4 +1,4 @@
-name: gtest disemvowel
+name: disemvowel-gtest
 
 on: [push, pull_request]
 #    paths:

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -3,10 +3,7 @@ name: gtest disemvowel
 on:
   [push, pull_request]:
     paths:
-    - disemvowel/**
-    paths-ignore:
-    - 'resources/**'
-    - '*.md'
+    - 'disemvowel/**'
 
 jobs:
   build:

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -1,9 +1,8 @@
 name: gtest disemvowel
 
-on:
-  [push, pull_request]:
-    paths:
-    - 'disemvowel/**'
+on: [push, pull_request]
+#    paths:
+#    - 'disemvowel/**'
 
 jobs:
   build:

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
     - name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp *.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Check ou the code
       uses: actions/checkout@v2
     - name: Compile test code

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
-      run: gcc -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test
       run: ./disemvowel_test

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -1,0 +1,37 @@
+name: disemvowel-main-valgrind
+
+on: [push, pull_request]
+#    paths:
+#    - 'disemvowel/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache gtest library
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-gtest-lib
+      with:
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
+        path: /usr/local/lib/libgtest.a
+        restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+    - name: Install gtest manually
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+    - name: Compile code
+      run: gcc -Wall -g -o disemvowel disemvowel.c main.c
+      working-directory: disemvowel
+    - name: Run test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel
+      working-directory: disemvowel
+
+# I need to split these into two tests. Otherwise I'm pretty sure if the second succeeds that
+# will "cover" any failures on the first call to `valgrind`. Alternatively I could use `||`,
+# but splitting them will provide different badges and more focused info for students.

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -29,7 +29,7 @@ jobs:
       run: gcc -Wall -g -o disemvowel disemvowel.c main.c
       working-directory: disemvowel
     - name: Run test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel
       working-directory: disemvowel
 
 # I need to split these into two tests. Otherwise I'm pretty sure if the second succeeds that

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -29,7 +29,7 @@ jobs:
       run: gcc -Wall -g -o disemvowel disemvowel.c main.c
       working-directory: disemvowel
     - name: Run test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel < main.c
       working-directory: disemvowel
 
 # I need to split these into two tests. Otherwise I'm pretty sure if the second succeeds that

--- a/.github/workflows/disemvowel_test_valgrind.yml
+++ b/.github/workflows/disemvowel_test_valgrind.yml
@@ -1,4 +1,4 @@
-name: disemvowel-valgrind
+name: disemvowel-test-valgrind
 
 on: [push, pull_request]
 #    paths:
@@ -26,13 +26,8 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: |
-        gcc -Wall -g -o disemvowel disemvowel.c main.c
-        g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test
-      run: |
-        valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel
-        valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel_test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel_test
       working-directory: disemvowel
-

--- a/.github/workflows/disemvowel_test_valgrind.yml
+++ b/.github/workflows/disemvowel_test_valgrind.yml
@@ -29,5 +29,5 @@ jobs:
       run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel_test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel_test
       working-directory: disemvowel

--- a/.github/workflows/disemvowel_valgrind.yml
+++ b/.github/workflows/disemvowel_valgrind.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Compile code
       run: |
-        gcc -Wall -g -o disemvowel disemvowel.c disemvowel_main.c
+        gcc -Wall -g -o disemvowel disemvowel.c main.c
         run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test

--- a/.github/workflows/disemvowel_valgrind.yml
+++ b/.github/workflows/disemvowel_valgrind.yml
@@ -26,11 +26,13 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: gcc -Wall -g -o disemvowel disemvowel.c disemvowel_main.c
-      run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
+      run: |
+        gcc -Wall -g -o disemvowel disemvowel.c disemvowel_main.c
+        run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel
-      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel_test
+      run: |
+        valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel
+        valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel_test
       working-directory: disemvowel
 

--- a/.github/workflows/disemvowel_valgrind.yml
+++ b/.github/workflows/disemvowel_valgrind.yml
@@ -1,0 +1,36 @@
+name: gtest-disemvowel
+
+on: [push, pull_request]
+#    paths:
+#    - 'disemvowel/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache gtest library
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-gtest-lib
+      with:
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
+        path: /usr/local/lib/libgtest.a
+        restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+    - name: Install gtest manually
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+    - name: Compile code
+      run: gcc -Wall -g -o disemvowel disemvowel.c disemvowel_main.c
+      run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
+      working-directory: disemvowel
+    - name: Run test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel
+      run: valgrind -v --leak-check=full --show-leak-kinds=all ./disemvowel_test
+      working-directory: disemvowel
+

--- a/.github/workflows/disemvowel_valgrind.yml
+++ b/.github/workflows/disemvowel_valgrind.yml
@@ -1,4 +1,4 @@
-name: gtest-disemvowel
+name: disemvowel-valgrind
 
 on: [push, pull_request]
 #    paths:

--- a/.github/workflows/disemvowel_valgrind.yml
+++ b/.github/workflows/disemvowel_valgrind.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Compile code
       run: |
         gcc -Wall -g -o disemvowel disemvowel.c main.c
-        run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
+        g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
       working-directory: disemvowel
     - name: Run test
       run: |

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -1,0 +1,32 @@
+name: palindrome-gtest
+
+on: [push, pull_request]
+#    paths:
+#    - 'palindrome/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache gtest library
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-gtest-lib
+      with:
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
+        path: /usr/local/lib/libgtest.a
+        restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+    - name: Install gtest manually
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+    - name: Check out the code
+      uses: actions/checkout@v2
+    - name: Compile test code
+      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -lgtest -pthread -std=c++0x
+      working-directory: palindrome
+    - name: Run test
+      run: ./palindrome_test
+      working-directory: palindrome
+

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -29,7 +29,7 @@ jobs:
       run: gcc -Wall -g -o palindrome palindrome.c main.c
       working-directory: palindrome
     - name: Run test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./palindrome
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./palindrome < sample_input.txt
       working-directory: palindrome
 
 # I need to split these into two tests. Otherwise I'm pretty sure if the second succeeds that

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -1,0 +1,37 @@
+name: palindrome-main-valgrind
+
+on: [push, pull_request]
+#    paths:
+#    - 'palindrome/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache gtest library
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-gtest-lib
+      with:
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
+        path: /usr/local/lib/libgtest.a
+        restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+    - name: Install gtest manually
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+    - name: Compile code
+      run: gcc -Wall -g -o palindrome palindrome.c main.c
+      working-directory: palindrome
+    - name: Run test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./palindrome
+      working-directory: palindrome
+
+# I need to split these into two tests. Otherwise I'm pretty sure if the second succeeds that
+# will "cover" any failures on the first call to `valgrind`. Alternatively I could use `||`,
+# but splitting them will provide different badges and more focused info for students.

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -1,0 +1,33 @@
+name: disemvowel-test-valgrind
+
+on: [push, pull_request]
+#    paths:
+#    - 'disemvowel/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache gtest library
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-gtest-lib
+      with:
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
+        path: /usr/local/lib/libgtest.a
+        restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+    - name: Install gtest manually
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+    - name: Install valgrind
+      run: sudo apt-get install -y valgrind
+    - name: Check out the code
+      uses: actions/checkout@v2
+    - name: Compile code
+      run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
+      working-directory: disemvowel
+    - name: Run test
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel_test
+      working-directory: disemvowel

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -1,8 +1,8 @@
-name: disemvowel-test-valgrind
+name: palindrome-test-valgrind
 
 on: [push, pull_request]
 #    paths:
-#    - 'disemvowel/**'
+#    - 'palindrome/**'
 
 jobs:
   build:
@@ -26,8 +26,8 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: g++ -Wall -g -o disemvowel_test disemvowel.c disemvowel_test.cpp -lgtest -pthread -std=c++0x
-      working-directory: disemvowel
+      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -lgtest -pthread -std=c++0x
+      working-directory: palindrome
     - name: Run test
-      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel_test
-      working-directory: disemvowel
+      run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./palindrome_test
+      working-directory: palindrome

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # C strings and memory management <!-- omit in toc -->
 
+[![Palindrome tests](../../workflows/palindrome-gtest/badge.svg)](../../actions?query=workflow%3A"palindrome-gtest")
+[![Palindrome main Valgrind](../../workflows/palindrome-main-valgrind/badge.svg)](../../actions?query=workflow%3A"palindrome-main-valgrind")
+[![Palindrome test Valgrind](../../workflows/palindrome-test-valgrind/badge.svg)](../../actions?query=workflow%3A"palindrome-test-valgrind")
+[![Disemvowel tests](../../workflows/disemvowel-gtest/badge.svg)](../../actions?query=workflow%3A"disemvowel-gtest")
+[![Disemvowel main Valgrind](../../workflows/disemvowel-main-valgrind/badge.svg)](../../actions?query=workflow%3A"disemvowel-main-valgrind")
+[![Disemvowel test Valgrind](../../workflows/disemvowel-test-valgrind/badge.svg)](../../actions?query=workflow%3A"disemvowel-test-valgrind")
+
+
 - [Background](#background)
   - [Testing and the Google Test framework](#testing-and-the-google-test-framework)
   - [Fixing memory problems](#fixing-memory-problems)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Testing and the Google Test framework](#testing-and-the-google-test-framework)
   - [Fixing memory problems](#fixing-memory-problems)
   - [Getting started](#getting-started)
+  - [GitHub Actions & automated tests](#github-actions--automated-tests)
 - [The problems](#the-problems)
   - [Fixing palindromes](#fixing-palindromes)
   - [Disemvowel](#disemvowel)
@@ -142,6 +143,25 @@ There are several flags here:
   (similar to the different versions of Java), and this says we want to use the
   `c++0x` standard from the 2000s (hence the `0x`). That's necessary or the test
   code won't compile correctly.
+
+### GitHub Actions & automated tests
+
+We've set up [GitHub Actions](../../actions) to automatically run
+six tests whenever you push new code up to your repo. All of these
+are also reflected (perhaps with some delay) with the badges
+at the top of this REAMDE.
+
+- `palindrome-gtest` runs the GTest tests on the Palindrome problem;
+  the badge is red if any of those tests fail.
+- `palindrome-main-valgrind` runs `valgrind` on the `main` program
+  for the Palindrome problem; the badge is red if there are any
+  memory leaks in running `valgrind` on that executable.
+- `palindrome-test-valgrind` runs `valgrind` on the executable
+  containing the GTest tests; the badge is red if there are any
+  memory leaks in running `valgrind` on that executable.
+
+There are then the same three tests, but for the Disemvowel
+problem.
 
 ---
 


### PR DESCRIPTION
The goal is to add GitHub Actions tests that run the GTest tests used in this lab, both to help the students and us in the grading.

I think I'm going to have to have this download and install `gtest`, which is likely to be expensive. Hopefully I can avoid duplicating this with caching, but I'm not entirely sure how yet. I think I'll need to do something with conditionals, but I'm not entirely sure what.

I'll need to run the tests for both `disemvowel` and `palindrome`, and make sure `valgrind` is happy for both of those as well.

Maybe the way to approach this is to have one action that _builds_ everything and then using caching to save those artifacts across tests? All I need are the final executables to check that the tests pass and that `valgrind` is happy.