### PR TITLE
Avoid installing gtest if it's in the cache

### DIFF
--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Check out the code

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -13,8 +13,10 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
-        path: /usr/local/lib/libgtest.a
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        path: |
+          /usr/lib/libgtest.a
+          /usr/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -1,6 +1,6 @@
 name: disemvowel-gtest
 
-on: [push, pull_request]
+on: push
 #    paths:
 #    - 'disemvowel/**'
 

--- a/.github/workflows/disemvowel_gtest.yml
+++ b/.github/workflows/disemvowel_gtest.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache gtest library
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-gtest-lib
       with:
@@ -19,7 +19,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - name: Install gtest manually
+    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+      name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Check out the code
       uses: actions/checkout@v2

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -18,7 +18,3 @@ jobs:
     - name: Run test
       run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./disemvowel < main.c
       working-directory: disemvowel
-
-# I need to split these into two tests. Otherwise I'm pretty sure if the second succeeds that
-# will "cover" any failures on the first call to `valgrind`. Alternatively I could use `||`,
-# but splitting them will provide different badges and more focused info for students.

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -13,8 +13,10 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
-        path: /usr/local/lib/libgtest.a
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        path: |
+          /usr/lib/libgtest.a
+          /usr/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -1,6 +1,6 @@
 name: disemvowel-main-valgrind
 
-on: [push, pull_request]
+on: push
 #    paths:
 #    - 'disemvowel/**'
 

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -8,22 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Cache gtest library
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-gtest-lib
-      with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
-        path: |
-          /usr/lib/libgtest.a
-          /usr/lib/libgtest_main.a
-        restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
-      name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind
     - name: Check out the code

--- a/.github/workflows/disemvowel_main_valgrind.yml
+++ b/.github/workflows/disemvowel_main_valgrind.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache gtest library
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-gtest-lib
       with:
@@ -19,7 +19,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - name: Install gtest manually
+    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+      name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind

--- a/.github/workflows/disemvowel_test_valgrind.yml
+++ b/.github/workflows/disemvowel_test_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind

--- a/.github/workflows/disemvowel_test_valgrind.yml
+++ b/.github/workflows/disemvowel_test_valgrind.yml
@@ -13,8 +13,10 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
-        path: /usr/local/lib/libgtest.a
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        path: |
+          /usr/lib/libgtest.a
+          /usr/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/disemvowel_test_valgrind.yml
+++ b/.github/workflows/disemvowel_test_valgrind.yml
@@ -1,6 +1,6 @@
 name: disemvowel-test-valgrind
 
-on: [push, pull_request]
+on: push
 #    paths:
 #    - 'disemvowel/**'
 

--- a/.github/workflows/disemvowel_test_valgrind.yml
+++ b/.github/workflows/disemvowel_test_valgrind.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache gtest library
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-gtest-lib
       with:
@@ -19,7 +19,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - name: Install gtest manually
+    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+      name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -1,6 +1,6 @@
 name: palindrome-gtest
 
-on: [push, pull_request]
+on: push
 #    paths:
 #    - 'palindrome/**'
 

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Check out the code

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -13,8 +13,10 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
-        path: /usr/local/lib/libgtest.a
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        path: |
+          /usr/lib/libgtest.a
+          /usr/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -13,21 +13,21 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('lib/libgtest.a') }}
         path: |
-          /usr/lib/libgtest.a
-          /usr/lib/libgtest_main.a
+          lib/libgtest.a
+          lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
     - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
-      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -Llib -lgtest -pthread -std=c++0x
       working-directory: palindrome
     - name: Run test
       run: ./palindrome_test

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -13,21 +13,21 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('lib/libgtest.a') }}
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('~/lib/libgtest.a') }}
         path: |
-          lib/libgtest.a
-          lib/libgtest_main.a
+          ~/lib/libgtest.a
+          ~/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
     - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo mkdir ~/lib && sudo cp -R lib/*.a ~/lib/
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
-      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -Llib -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -L"~/lib" -lgtest -pthread -std=c++0x
       working-directory: palindrome
     - name: Run test
       run: ./palindrome_test

--- a/.github/workflows/palindrome_gtest.yml
+++ b/.github/workflows/palindrome_gtest.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache gtest library
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-gtest-lib
       with:
@@ -19,7 +19,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - name: Install gtest manually
+    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+      name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Check out the code
       uses: actions/checkout@v2

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -1,6 +1,6 @@
 name: palindrome-main-valgrind
 
-on: [push, pull_request]
+on: push
 #    paths:
 #    - 'palindrome/**'
 

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -13,8 +13,10 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
-        path: /usr/local/lib/libgtest.a
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        path: |
+          /usr/lib/libgtest.a
+          /usr/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -8,22 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Cache gtest library
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-gtest-lib
-      with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
-        path: |
-          /usr/lib/libgtest.a
-          /usr/lib/libgtest_main.a
-        restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
-      name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind
     - name: Check out the code

--- a/.github/workflows/palindrome_main_valgrind.yml
+++ b/.github/workflows/palindrome_main_valgrind.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache gtest library
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-gtest-lib
       with:
@@ -19,7 +19,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - name: Install gtest manually
+    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+      name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -14,7 +14,9 @@ jobs:
         cache-name: cache-gtest-lib
       with:
         key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
-        path: /usr/lib/libgtest.a
+        path: |
+          /usr/lib/libgtest.a
+          /usr/lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -25,9 +25,7 @@ jobs:
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
-      run: |
-        sudo apt-get install -y valgrind
-        which valgrind
+      run: sudo apt-get install -y valgrind
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -13,8 +13,8 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/local/lib/libgtest.a') }}
-        path: /usr/local/lib/libgtest.a
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        path: /usr/lib/libgtest.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -13,23 +13,23 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('lib/libgtest.a') }}
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('~/lib/libgtest.a') }}
         path: |
-          lib/libgtest.a
-          lib/libgtest_main.a
+          ~/lib/libgtest.a
+          ~/lib/libgtest_main.a
         restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
     - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo mkdir ~/lib && sudo cp -R lib/*.a ~/lib/
     - name: Install valgrind
       run: sudo apt-get install -y valgrind
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -Llib -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -L"~/lib" -lgtest -pthread -std=c++0x
       working-directory: palindrome
     - name: Run test
       run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./palindrome_test

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+    - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -25,8 +25,9 @@ jobs:
       name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
-      run: sudo apt-get install -y valgrind
-      run: which valgrind
+      run: |
+        sudo apt-get install -y valgrind
+        which valgrind
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -15,8 +15,8 @@ jobs:
       with:
         key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('lib/libgtest.a') }}
         path: |
-          libgtest.a
-          libgtest_main.a
+          lib/libgtest.a
+          lib/libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -1,6 +1,6 @@
 name: palindrome-test-valgrind
 
-on: [push, pull_request]
+on: push
 #    paths:
 #    - 'palindrome/**'
 

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -26,6 +26,7 @@ jobs:
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind
+      run: which valgrind
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache gtest library
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-gtest-lib
       with:
@@ -19,7 +19,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-    - name: Install gtest manually
+    - if ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
+      name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Install valgrind
       run: sudo apt-get install -y valgrind

--- a/.github/workflows/palindrome_test_valgrind.yml
+++ b/.github/workflows/palindrome_test_valgrind.yml
@@ -13,23 +13,23 @@ jobs:
       env:
         cache-name: cache-gtest-lib
       with:
-        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/usr/lib/libgtest.a') }}
+        key: $${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('lib/libgtest.a') }}
         path: |
-          /usr/lib/libgtest.a
-          /usr/lib/libgtest_main.a
+          libgtest.a
+          libgtest_main.a
         restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
     - if: ${{ steps.cache-gtest-lib.cache-hit != 'true' }}
       name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make
     - name: Install valgrind
       run: sudo apt-get install -y valgrind
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o palindrome_test palindrome.c palindrome_test.cpp -Llib -lgtest -pthread -std=c++0x
       working-directory: palindrome
     - name: Run test
       run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./palindrome_test


### PR DESCRIPTION
I'm hoping that this will actually _use_ the cache (that I think was being ignored) to avoid redownloading and installing the `gtest` library over and over in our GitHub Actions, thus speeding them up.

I don't honestly think that the caching works yet, but it's possible that the changes have to be merged into `main` for us to know for sure, so I'm going to go ahead and merge this in, hoping for the best. There are some useful/important changes here (e.g., avoiding duplicate builds because of both `push` and `pull-request`), so it's worth having these changes regardless.